### PR TITLE
fix: exit on connection error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ const main = async () => {
       );
     } catch (ex) {
       console.error(ex);
+      process.exit(1);
     }
   }
 };

--- a/src/lib/acker.ts
+++ b/src/lib/acker.ts
@@ -3,10 +3,15 @@ import { Pool, Notification } from 'pg';
 
 const REQUEUE_CHECK = 30000;
 
+let timeout: NodeJS.Timeout = undefined;
+process.on('exit', () => {
+  if (timeout) clearTimeout(timeout);
+});
+
 export const createAcker = () => {
   const pool = new Pool({ connectionString: config.databaseUrl });
 
-  setTimeout(async () => {
+  timeout = setTimeout(async () => {
     console.log(`Renotifying unacked jobs older than ${REQUEUE_CHECK}`);
     try {
       await pool.query(

--- a/src/lib/listener.ts
+++ b/src/lib/listener.ts
@@ -10,6 +10,10 @@ const subscriber = createSubscriber(
   { parse: s => s }
 );
 
+process.on('exit', () => {
+  subscriber.close();
+});
+
 type Listener = (msg: Notification) => void;
 
 export const registerListener = async (channel: string, fns: Listener[]) => {
@@ -20,7 +24,7 @@ export const registerListener = async (channel: string, fns: Listener[]) => {
   subscriber.events.on('error', (err: Error) => {
     console.error('Client got fatal error', err);
     console.log('Shutting down...');
-    process.exit();
+    process.exit(1);
   });
 
   await subscriber.connect();


### PR DESCRIPTION
We need to exit, not just log the error, for the case where a Postgres connection cannot be
established by subscriber.connect() in registerListener().

Tear down open connections and timers in order to exit cleanly.

It might also be worth adding this to the `acker`'s renotify unacked jobs catch block

```js
      // Exit if it was a connection issue
      if (ex.code === 'ECONNREFUSED') {
        process.exit(1);
      }
```